### PR TITLE
Cache should be customer dependant

### DIFF
--- a/ps_specials.php
+++ b/ps_specials.php
@@ -248,4 +248,13 @@ class Ps_Specials extends Module implements WidgetInterface
 
         return $products_for_template;
     }
+    
+    protected function getCacheId($name = null)
+    {
+        $cacheId = parent::getCacheId($name);
+        if(!empty($this->context->customer->id)){
+            $cacheId .= '|' . (int) $this->context->customer->id;
+        }
+        return $cacheId;
+    }    
 }

--- a/ps_specials.php
+++ b/ps_specials.php
@@ -252,7 +252,7 @@ class Ps_Specials extends Module implements WidgetInterface
     protected function getCacheId($name = null)
     {
         $cacheId = parent::getCacheId($name);
-        if(!empty($this->context->customer->id)){
+        if (!empty($this->context->customer->id)) {
             $cacheId .= '|' . (int) $this->context->customer->id;
         }
         return $cacheId;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | There are several issues in native modules because module cache is not customer dependant.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#17111
| How to test?      | Add a customer dependent product price, load home page. Authenticate to another user of the same group : the price should be different.
| Possible impacts? | The cache will grow up.