### PR TITLE
Assemble products in bulk to save performance

### DIFF
--- a/ps_specials.php
+++ b/ps_specials.php
@@ -256,13 +256,19 @@ class Ps_Specials extends Module implements WidgetInterface
             );
         }
 
+        // Now, we can present the products for the template.
         $products_for_template = [];
 
         if (is_array($products)) {
+            // Assemble & present in bulk or separately, depending on core version
+            $assembleInBulk = method_exists($assembler, 'assembleProducts');
+            if ($assembleInBulk) {
+                $products = $assembler->assembleProducts($products);
+            }
             foreach ($products as $rawProduct) {
                 $products_for_template[] = $presenter->present(
                     $presentationSettings,
-                    $assembler->assembleProduct($rawProduct),
+                    ($assembleInBulk ? $rawProduct : $assembler->assembleProduct($rawProduct)),
                     $this->context->language
                 );
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Uses `assembleProducts` method added in 9.0 (https://github.com/PrestaShop/PrestaShop/pull/37399) for getting product data if it exists. This makes it load the data in just one query instead of n products.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Test that the module works correctly

### Related simmilar PRs:
https://github.com/PrestaShop/ps_newproducts/pull/29
https://github.com/PrestaShop/ps_specials/pull/19
https://github.com/PrestaShop/ps_bestsellers/pull/36
https://github.com/PrestaShop/ps_categoryproducts/pull/42
https://github.com/PrestaShop/ps_crossselling/pull/47
https://github.com/PrestaShop/ps_featuredproducts/pull/59
https://github.com/PrestaShop/ps_viewedproduct/pull/38