### PR TITLE
fix(hooknames): correct SpecificPrice hook names (Core* hooks do…

### DIFF
--- a/ps_specials.php
+++ b/ps_specials.php
@@ -69,9 +69,9 @@ class Ps_Specials extends Module implements WidgetInterface
             && $this->registerHook('actionProductAdd')
             && $this->registerHook('actionProductUpdate')
             && $this->registerHook('actionProductDelete')
-            && $this->registerHook('actionObjectSpecificPriceCoreDeleteAfter')
-            && $this->registerHook('actionObjectSpecificPriceCoreAddAfter')
-            && $this->registerHook('actionObjectSpecificPriceCoreUpdateAfter')
+            && $this->registerHook('actionObjectSpecificPriceDeleteAfter')
+            && $this->registerHook('actionObjectSpecificPriceAddAfter')
+            && $this->registerHook('actionObjectSpecificPriceUpdateAfter')
             && $this->registerHook('displayHome');
     }
 
@@ -97,17 +97,17 @@ class Ps_Specials extends Module implements WidgetInterface
         $this->_clearCache('*');
     }
 
-    public function hookActionObjectSpecificPriceCoreDeleteAfter($params)
+    public function hookActionObjectSpecificPriceDeleteAfter($params)
     {
         $this->_clearCache('*');
     }
 
-    public function hookActionObjectSpecificPriceCoreAddAfter($params)
+    public function hookActionObjectSpecificPriceAddAfter($params)
     {
         $this->_clearCache('*');
     }
 
-    public function hookActionObjectSpecificPriceCoreUpdateAfter($params)
+    public function hookActionObjectSpecificPriceUpdateAfter($params)
     {
         $this->_clearCache('*');
     }

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -1,0 +1,35 @@
+<?php
+/*
+* 2007-2014 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2014 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/upgrade/upgrade-1.0.4.php
+++ b/upgrade/upgrade-1.0.4.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2016 PrestaShop SA
+ *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * @param Module $module
+ *
+ * @return bool
+ */
+function upgrade_module_1_0_4($object)
+{
+    $hooksToUnregister = [
+        'actionObjectSpecificPriceCoreAddAfter',
+        'actionObjectSpecificPriceCoreUpdateAfter',
+        'actionObjectSpecificPriceCoreDeleteAfter',
+    ];
+
+    foreach ($hooksToUnregister as $hookName) {
+        // Unregister module from hook
+        $object->unregisterHook($hookName);
+        $hookId = Hook::getIdByName($hookName);
+
+        // Remove unused hook created by mistake
+        if ($hookId && Validate::isLoadedObject($hook = new Hook($hookId))) {
+            $hook->delete();
+        }
+    }
+
+    $object->registerHook([
+        'actionObjectSpecificPriceAddAfter',
+        'actionObjectSpecificPriceUpdateAfter',
+        'actionObjectSpecificPriceDeleteAfter',
+    ]);
+
+    return true;
+}

--- a/upgrade/upgrade-1.0.4.php
+++ b/upgrade/upgrade-1.0.4.php
@@ -29,7 +29,7 @@
  *
  * @return bool
  */
-function upgrade_module_1_0_4($object)
+function upgrade_module_1_0_4($module)
 {
     $hooksToUnregister = [
         'actionObjectSpecificPriceCoreAddAfter',
@@ -39,7 +39,7 @@ function upgrade_module_1_0_4($object)
 
     foreach ($hooksToUnregister as $hookName) {
         // Unregister module from hook
-        $object->unregisterHook($hookName);
+        $module->unregisterHook($hookName);
         $hookId = Hook::getIdByName($hookName);
 
         // Remove unused hook created by mistake
@@ -48,7 +48,7 @@ function upgrade_module_1_0_4($object)
         }
     }
 
-    $object->registerHook([
+    $module->registerHook([
         'actionObjectSpecificPriceAddAfter',
         'actionObjectSpecificPriceUpdateAfter',
         'actionObjectSpecificPriceDeleteAfter',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | This PR fixes the registration of **SpecificPrice hooks** in the ps_specials module.<br/>The module was using the following **non-existent hooks**:<br/>- `actionObjectSpecificPriceCoreAddAfter`<br/>- `actionObjectSpecificPriceCoreUpdateAfter`<br/>- `actionObjectSpecificPriceCoreDeleteAfter`<br/>In PrestaShop, the correct and existing hooks are:<br/>- `actionObjectSpecificPriceAddAfter`<br/>- `actionObjectSpecificPriceUpdateAfter`<br/>- `actionObjectSpecificPriceDeleteAfter`<br/>The hooks have been updated accordingly to ensure that ps_specials reacts properly when a SpecificPrice is added, updated, or deleted.| Type?             | bug fix / improvement / new feature / refacto / critical
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | 
| How to test?      | 1. In Advanced Parameters > Performance, set Cache to YES<br> 2. Go to a product and add a discount (specific price)<br>3. Go to the homepage (front-office site) – the product should appear in the "On sale" block<br>4. Delete the product’s specific price<br>5. Go to the homepage (front-office site) – the product should no longer be in the "On sale" block
| Sponsor company   | Codencode snc

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
