### PR TITLE
Change product sort for performance and UX

### DIFF
--- a/ps_specials.php
+++ b/ps_specials.php
@@ -227,7 +227,9 @@ class Ps_Specials extends Module implements WidgetInterface
         $products = Product::getPricesDrop(
             (int) Context::getContext()->language->id,
             0,
-            (int) Configuration::get('BLOCKSPECIALS_SPECIALS_NBR')
+            (int) Configuration::get('BLOCKSPECIALS_SPECIALS_NBR'),
+            'id_product',
+            'DESC'
         );
 
         $assembler = new ProductAssembler($this->context);

--- a/ps_specials.php
+++ b/ps_specials.php
@@ -229,7 +229,7 @@ class Ps_Specials extends Module implements WidgetInterface
             0,
             (int) Configuration::get('BLOCKSPECIALS_SPECIALS_NBR'),
             false,
-            'id_product',
+            'date_add',
             'DESC'
         );
 

--- a/ps_specials.php
+++ b/ps_specials.php
@@ -228,6 +228,7 @@ class Ps_Specials extends Module implements WidgetInterface
             (int) Context::getContext()->language->id,
             0,
             (int) Configuration::get('BLOCKSPECIALS_SPECIALS_NBR'),
+            false,
             'id_product',
             'DESC'
         );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Change product sort for performance and UX, see bellow
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | Go to front home page and see changes
| Sponsor company   | Creabilis.com

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Actually the on sale products are sorted by price desc, two issues :
- Huge performance issue for large catalog because Product::getPricesDrop fetch all products, than compute price, then sort in php, than cut to 8. This behavior can really slow down the home page.
- UX issue : for most shops, display the more expensive product first is not that relevant, so last created products is better.