### PR TITLE
Remove caching system and bump version to 2.0.0

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_specials</name>
     <displayName><![CDATA[Specials block]]></displayName>
-    <version><![CDATA[1.0.3]]></version>
+    <version><![CDATA[2.0.0]]></version>
     <description><![CDATA[Displays your products that are currently on sale in a dedicated block.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <is_configurable>1</is_configurable>

--- a/ps_specials.php
+++ b/ps_specials.php
@@ -42,7 +42,7 @@ class Ps_Specials extends Module implements WidgetInterface
         $this->name = 'ps_specials';
         $this->tab = 'front_office_features';
         $this->author = 'PrestaShop';
-        $this->version = '1.0.3';
+        $this->version = '2.0.0';
         $this->need_instance = 0;
 
         $this->ps_versions_compliancy = [
@@ -61,60 +61,14 @@ class Ps_Specials extends Module implements WidgetInterface
 
     public function install()
     {
-        $this->_clearCache('*');
-
         Configuration::updateValue('BLOCKSPECIALS_SPECIALS_NBR', 8);
 
-        return parent::install()
-            && $this->registerHook('actionProductAdd')
-            && $this->registerHook('actionProductUpdate')
-            && $this->registerHook('actionProductDelete')
-            && $this->registerHook('actionObjectSpecificPriceDeleteAfter')
-            && $this->registerHook('actionObjectSpecificPriceAddAfter')
-            && $this->registerHook('actionObjectSpecificPriceUpdateAfter')
-            && $this->registerHook('displayHome');
+        return parent::install() && $this->registerHook('displayHome');
     }
 
     public function uninstall()
     {
-        $this->_clearCache('*');
-
         return parent::uninstall();
-    }
-
-    public function hookActionProductAdd($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function hookActionProductUpdate($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function hookActionProductDelete($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function hookActionObjectSpecificPriceDeleteAfter($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function hookActionObjectSpecificPriceAddAfter($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function hookActionObjectSpecificPriceUpdateAfter($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function _clearCache($template, $cache_id = null, $compile_id = null)
-    {
-        return parent::_clearCache($this->templateFile);
     }
 
     public function getContent()
@@ -130,8 +84,6 @@ class Ps_Specials extends Module implements WidgetInterface
                 $output = $this->displayError($errors);
             } else {
                 Configuration::updateValue('BLOCKSPECIALS_SPECIALS_NBR', (int) Tools::getValue('BLOCKSPECIALS_SPECIALS_NBR'));
-
-                $this->_clearCache('*');
 
                 $output .= $this->displayConfirmation($this->trans('The settings have been updated.', [], 'Admin.Notifications.Success'));
             }
@@ -178,7 +130,9 @@ class Ps_Specials extends Module implements WidgetInterface
             '&module_name=' . $this->name;
         $helper->token = Tools::getAdminTokenLite('AdminModules');
         $helper->tpl_vars = [
-            'fields_value' => $this->getConfigFieldsValues(),
+            'fields_value' => [
+                'BLOCKSPECIALS_SPECIALS_NBR' => Tools::getValue('BLOCKSPECIALS_SPECIALS_NBR', Configuration::get('BLOCKSPECIALS_SPECIALS_NBR')),
+            ],
             'languages' => $this->context->controller->getLanguages(),
             'id_language' => $this->context->language->id,
         ];
@@ -186,26 +140,17 @@ class Ps_Specials extends Module implements WidgetInterface
         return $helper->generateForm([$fields_form]);
     }
 
-    public function getConfigFieldsValues()
-    {
-        return [
-            'BLOCKSPECIALS_SPECIALS_NBR' => Tools::getValue('BLOCKSPECIALS_SPECIALS_NBR', Configuration::get('BLOCKSPECIALS_SPECIALS_NBR')),
-        ];
-    }
-
     public function renderWidget($hookName = null, array $configuration = [])
     {
-        if (!$this->isCached($this->templateFile, $this->getCacheId('ps_specials'))) {
-            $variables = $this->getWidgetVariables($hookName, $configuration);
+        $variables = $this->getWidgetVariables($hookName, $configuration);
 
-            if (empty($variables)) {
-                return false;
-            }
-
-            $this->smarty->assign($variables);
+        if (empty($variables)) {
+            return false;
         }
 
-        return $this->fetch($this->templateFile, $this->getCacheId('ps_specials'));
+        $this->smarty->assign($variables);
+
+        return $this->fetch($this->templateFile);
     }
 
     public function getWidgetVariables($hookName = null, array $configuration = [])
@@ -263,15 +208,5 @@ class Ps_Specials extends Module implements WidgetInterface
         }
 
         return $products_for_template;
-    }
-
-    protected function getCacheId($name = null)
-    {
-        $cacheId = parent::getCacheId($name);
-        if (!empty($this->context->customer->id)) {
-            $cacheId .= '|' . (int) $this->context->customer->id;
-        }
-
-        return $cacheId;
     }
 }

--- a/upgrade/upgrade-2.0.0.php
+++ b/upgrade/upgrade-2.0.0.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2016 PrestaShop SA
+ *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * @param Module $module
+ *
+ * @return bool
+ */
+function upgrade_module_2_0_0($module)
+{
+    $hooksToUnregister = [
+        'actionProductAdd',
+        'actionProductUpdate',
+        'actionProductDelete',
+        'actionObjectSpecificPriceDeleteAfter',
+        'actionObjectSpecificPriceAddAfter',
+        'actionObjectSpecificPriceUpdateAfter',
+    ];
+
+    foreach ($hooksToUnregister as $hookName) {
+        $module->unregisterHook($hookName);
+    }
+
+    return true;
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Removes caching system from this module to fix all issues with outdated data being displayed on homepage. Once you display anything more than a price on the product miniature, the data is outdated. Availability displays yesterdays date or wrong message. There is only a negligible slowdown, it's only 8 products, we load much more in a category, where there is no caching.
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Sponsor company   | TRENDO s.r.o.